### PR TITLE
import queue for Queue as module name to support python3 and python27

### DIFF
--- a/api_client/eventlet_client.py
+++ b/api_client/eventlet_client.py
@@ -20,7 +20,7 @@ import time
 import eventlet
 eventlet.monkey_patch()
 from oslo_log import log as logging
-import Queue
+import queue
 
 from ._i18n import _LE
 from . import base


### PR DESCRIPTION
python3 doesn't have Queue but queue, they are the same for python27
so import queue.