### PR TITLE
use debug level for bad status errors

### DIFF
--- a/api_client/base.py
+++ b/api_client/base.py
@@ -275,10 +275,10 @@ class ApiClientBase(object):
 
         if bad_state:
             # Reconnect to provider.
-            LOG.warning(_LW("[%(rid)d] Connection returned in bad state, "
-                            "reconnecting to %(conn)s"),
-                        {'rid': rid,
-                         'conn': utils.ctrl_conn_to_str(http_conn)})
+            LOG.debug("[%(rid)d] Connection returned in bad state, "
+                      "reconnecting to %(conn)s",
+                      {'rid': rid,
+                       'conn': utils.ctrl_conn_to_str(http_conn)})
             http_conn.close()
             http_conn = self._create_connection(*self._conn_params(http_conn))
             conns = []

--- a/api_client/eventlet_request.py
+++ b/api_client/eventlet_request.py
@@ -147,7 +147,7 @@ class EventletApiRequest(request.ApiRequest):
                     msg = ("# request {method} {url} {body} error {e}"
                            ).format(method=self._method, url=self._url,
                                     body=self._body, e=e)
-                    LOG.error(msg)
+                    LOG.debug(msg)
                     continue
             # automatically raises any exceptions returned.
             if isinstance(req, httplib.HTTPResponse):


### PR DESCRIPTION
connection pool will timeout if left idle, so that would be normal
and it is better to put those error log in debug level to avoid
confusion