### PR TITLE
use debug level for BadStatusLine errors

### DIFF
--- a/api_client/request.py
+++ b/api_client/request.py
@@ -223,16 +223,17 @@ class ApiRequest(object):
             return response
 
         except Exception as e:
+            elapsed_time = time.time() - issued_time
             if isinstance(e, httpclient.BadStatusLine):
                 msg = "Invalid server response"
+                log_func = LOG.debug
             else:
                 msg = str(e)
-            if response is None:
-                elapsed_time = time.time() - issued_time
-            LOG.warning(("[{rid}] Failed request '{conn}': '{msg}' "
-                        "({elapsed} seconds), error type '{err}'.").format(
-                        rid=self._rid(), conn=self._request_str(conn, url),
-                        msg=msg, elapsed=elapsed_time, err=type(e)))
+                log_func = LOG.warning
+            log_func(("[{rid}] Failed request '{conn}': '{msg}' "
+                      "({elapsed} seconds), error type '{err}'.").format(
+                      rid=self._rid(), conn=self._request_str(conn, url),
+                      msg=msg, elapsed=elapsed_time, err=type(e)))
             self._request_error = e
             is_conn_error = True
             if isinstance(e, (httpclient.BadStatusLine, socket.error)):


### PR DESCRIPTION
because the connection pool will timeout if not sending any requests,
badstatusline error is inevitable, it is not necessary to use warning
level, which makes a lot of noises.