### PR TITLE
fix fortipam cookie expiration issue

### DIFF
--- a/api_client/base.py
+++ b/api_client/base.py
@@ -215,7 +215,7 @@ class ApiClientBase(object):
             cookies = Cookie.SimpleCookie(cookie)
             for key, morsel in six.iteritems(cookies):
                 if "ccsrftoken" in morsel.key:
-                    morsel.coded_value = morsel.value
+                    #morsel.coded_value = morsel.value
                     fmt_headers["X-CSRFTOKEN"] = morsel.value
                     break
             fmt_headers["Cookie"] = cookies.output(header="").lstrip()

--- a/api_client/eventlet_request.py
+++ b/api_client/eventlet_request.py
@@ -158,7 +158,8 @@ class EventletApiRequest(request.ApiRequest):
                     # the bug to handle return 400 situation.
                     # when fortios fix the bug, here should use
                     # 'req.status in (401, 403)' instead
-                    if req.status in (400, 401, 403):
+                    # 303 for fortipam cookie expiration code
+                    if req.status in (400, 401, 403, 303):
                         continue
                     elif req.status == 503:
                         timeout = 0.5

--- a/api_client/request.py
+++ b/api_client/request.py
@@ -172,7 +172,7 @@ class ApiRequest(object):
                            'response.headers': response.headers,
                            'response.body': response_body})
 
-                if response.status in (401, 302):
+                if response.status in (401, 302, 303):
                     # if response.headers:
                     login_msg = self._api_client.login_msg()
                     if auth is None and login_msg:


### PR DESCRIPTION
fortipam uses 303 for expired session
morsel value is read-only can't be changed