### PR TITLE
reformat cookies to avoid newline

### DIFF
--- a/api_client/base.py
+++ b/api_client/base.py
@@ -207,14 +207,17 @@ class ApiClientBase(object):
         if not cookie:
             return None
         try:
+            formatted_cookie = ""
             fmt_headers = {}
             cookies = Cookie.SimpleCookie(cookie)
             for key, morsel in six.iteritems(cookies):
+                # samesite is not reserved in python3.6
+                if morsel.isReservedKey(key) or key.lower() == 'samesite':
+                    continue
                 if "ccsrftoken" in morsel.key:
-                    # morsel.coded_value = morsel.value
                     fmt_headers["X-CSRFTOKEN"] = morsel.value
-                    break
-            fmt_headers["Cookie"] = cookies.output(header="").lstrip()
+                formatted_cookie += f"{key}={morsel.value}; "
+            fmt_headers["Cookie"] = formatted_cookie.rstrip()
             return fmt_headers
         except (Cookie.CookieError, KeyError):
             LOG.error(_LE("The cookie ccsrftoken cannot be formatted"))


### PR DESCRIPTION
new fortiproduct api rejects headers with newline
reformat cookies to avoid newline